### PR TITLE
kompira-v2 リポジトリでの docker-compose.yml への修正を移植しました

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,21 +19,48 @@ Kompira Enterprise は IT 運用管理業務の自動化を支援するための
 
 ## 3. クイックスタート
 
-Docker と git コマンドがインストールされているサーバ上で、以下のコマンドを実行することで、すぐに使い始めることができます。
+Docker エンジンと git コマンドがインストールされているサーバであれば、以下のコマンドを実行することですぐに使い始めることができます。
 
+```
 $ git clone https://github.com/fixpoint/ke-docker.git
 $ cd ke-docker/allinone
-$ LOCAL_UID=$UID LOCAL_GID=$(id -g) docker compose pull
-$ LOCAL_UID=$UID LOCAL_GID=$(id -g) docker compose up -d
+$ export LOCAL_UID=$UID LOCAL_GID=$(id -g)
+$ docker compose pull
+$ docker compose up -d
+```
 
-ブラウザから Docker コンテナが動作しているサーバにアクセス (https://<サーバのアドレス>/.login) するとログイン画面が表示されるので、以下のアカウントでログインすることで Kompira をはじめることができます。
+ブラウザから Docker エンジンが動作しているサーバにアクセス (https://<サーバのアドレス>/.login) するとログイン画面が表示されます。
+以下のアカウントでログインして Kompira をはじめることができます。
 
 * ユーザ名: `root`
 * パスワード: `root`
 
 ログイン後の画面の右上にある「ヘルプ」をクリックすると、オンラインマニュアルが表示されますので使い方の参考にしてください。
 
-## 4. Kompira ライセンス
+## 4. 準備と設定
+### 4.1. Docker エンジンの準備
+
+Docker エンジンのインストール手順と起動方法については以下を参考にしてください。
+
+https://docs.docker.com/engine/install/
+
+### 4.2. 環境変数の設定
+
+デプロイ時に環境変数を設定しておくことで、Kompira の動作環境を指定することが出来ます。
+以下では各構成で共通的な環境変数について示します。
+各構成で独自の環境変数が定義されている場合もありますのでそれぞれの README.md を参照してください。
+
+
+| 環境変数        | 意味                        | デフォルト値                            | 備考                                                   |
+| --------------- | --------------------------- | --------------------------------------- | ------------------------------------------------------ |
+| `TZ`            | タイムゾーン                | "Asia/Tokyo"                            | 画面やログで表示される時刻のタイムゾーンを指定します   |
+| `LANGUAGE_CODE` | 言語コード ("ja" or "en")   | "ja"                                    | 初回起動時にインポートする初期データの言語を指定します |
+| `IMAGE_NAME`    | Kompira イメージ            | "kompira.azurecr.io/kompira-enterprise" | デプロイする Kompira コンテナのイメージを指定します    |
+| `IMAGE_TAG`     | Kompira タグ                | "latest"                                | デプロイする Kompira コンテナのタグを指定します        |
+| `LOCAL_UID`     | ローカル実行ユーザID        | (無し)                                  | fluentd コンテナを実行するユーザIDを指定します         |
+| `LOCAL_GID`     | ローカル実行グループID      | (無し)                                  | fluentd コンテナを実行するグループIDを指定します       |
+
+## 5. Kompira ライセンス
 
 [Kompira Enterprise ライセンス利用規約](https://www.kompira.jp/Kompira_terms.pdf)に同意の上、ダウンロードページからダウンロードして下さい。
 
@@ -41,12 +68,12 @@ Kompira の使用には、ライセンス登録が必要です。詳しくは [l
 
 ※ ご利用の Kompira のバージョンに依らず、最新のライセンス利用規約が適用されます。
 
-## 5. Kompira 関連の情報
+## 6. Kompira 関連の情報
 
-### 5.1. Kompira 運用自動化コラム
+### 6.1. Kompira 運用自動化コラム
 
 Kompira の実践的な使い方やジョブフローの書き方については [運用自動化コラム](https://www.kompira.jp/column/) を参考にしてみてください。
 
-### 5.2. Kompira コミュニティサイト
+### 6.2. Kompira コミュニティサイト
 
 Kompira の使い方が分からない場合などは、 [コミュニティ> KompiraEnterprise関連](https://kompira.zendesk.com/hc/ja/community/topics/360000014321-KompiraEnterprise%E9%96%A2%E9%80%A3) を参考にしてみてください。同じような質問や回答が見つからない場合は、新たに投稿してみてください。

--- a/allinone/README.md
+++ b/allinone/README.md
@@ -9,29 +9,36 @@ Docker コンテナで動作させるため、簡単に始めることができ�
 
 以下のコマンドを実行して Kompira Enterprise 開始します。
 
+```
 $ export LOCAL_UID=$UID LOCAL_GID=$(id -g)
-
 $ docker compose pull
 $ docker compose up -d
+```
 
 ### システムの停止
 
 Kompira Enterprise を停止するには以下のコマンドを実行します。
 
+```
 $ docker compose stop
+```
 
 ### システムの再開
 
 停止した Kompira Enterprise を再開するには以下のコマンドを実行します。
 (代わりに docker compose up -d を使うことも可能です)
 
+```
 $ docker compose start
+```
 
 ### システムの削除
 
 以下のコマンドを実行すると、システムが停止し、すべてのコンテナとデータが削除されます。
 
+```
 $ docker compose down -v
+```
 
 -v オプションを指定しない場合、コンテナのみ削除され、データは残されます。
 したがって、再び docker compose up -d 開始すると、以前のデータにアクセスすることができます。
@@ -47,4 +54,6 @@ Nginx と RabbitMQ で SSL を利用するには、ホスト側の ke-docker/ssl
 
 docker-compose.override.yml.sample を docker-compose.override.yml にコピーしてから、以下のコマンドを実行します。
 
+```
 $ docker compose up -d
+```

--- a/allinone/docker-compose.yml
+++ b/allinone/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     volumes:
       - ../configs/fluentd.conf:/fluentd/etc/fluent.conf:ro
       - ./log:/var/log/fluentd
+    environment:
+      TZ: ${TZ:-Asia/Tokyo}
+      LOCAL_UID: ${LOCAL_UID:?LOCAL_UID must be set, try "export LOCAL_UID=$$(id -u $${USER})"}
+      LOCAL_GID: ${LOCAL_GID:?LOCAL_GID must be set, try "export LOCAL_GID=$$(id -g $${USER})"}
     user: "${LOCAL_UID}:${LOCAL_GID}"
     ports:
       - "24224:24224"
@@ -20,6 +24,7 @@ services:
     environment:
       POSTGRES_PASSWORD: kompira
       POSTGRES_USER: kompira
+      TZ: ${TZ:-Asia/Tokyo}
     logging:
       driver: fluentd
       options:
@@ -30,12 +35,13 @@ services:
     restart: always
   kompira:
     container_name: kompira-app
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
     environment:
       - DATABASE_URL=pgsql://kompira:kompira@postgres:5432/kompira
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - CACHE_URL=redis://redis:6379
-      - TZ=Asia/Tokyo
+      - LANGUAGE_CODE=${LANGUAGE_CODE:-ja}
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira_audit.yaml:/opt/kompira/kompira_audit.yaml:ro
@@ -53,12 +59,13 @@ services:
     restart: always
   kengine:
     container_name: kompira-engine
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
     environment:
       - DATABASE_URL=pgsql://kompira:kompira@postgres:5432/kompira
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - CACHE_URL=redis://redis:6379
-      - TZ=Asia/Tokyo
+      - LANGUAGE_CODE=${LANGUAGE_CODE:-ja}
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira_audit.yaml:/opt/kompira/kompira_audit.yaml:ro
@@ -78,7 +85,9 @@ services:
     restart: always
   jobmngrd:
     container_name: kompira-jobmngr
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira.conf:/opt/kompira/kompira.conf:ro
@@ -98,6 +107,8 @@ services:
   redis:
     container_name: kompira-cache
     image: redis:7.2-alpine
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_redis:/data
     logging:
@@ -111,6 +122,8 @@ services:
   nginx:
     container_name: kompira-web
     image: nginx:1.25-alpine
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/nginx-default.conf:/etc/nginx/conf.d/default.conf:ro
@@ -133,6 +146,7 @@ services:
       - kompira_mq:/var/lib/rabbitmq     # volume名を明示的に指定 (指定しないとハッシュ化された文字列のボリューム名が使われてゴミが増える)
     environment:
       RABBITMQ_DATA_DIR: /var/lib/rabbitmq    # デフォルト値なので指定不要だが、ボリュームのマウントポイントと一致させるために明示的に指定しておく
+      TZ: ${TZ:-Asia/Tokyo}
     logging:
       driver: fluentd
       options:

--- a/withoutdb/README.md
+++ b/withoutdb/README.md
@@ -46,30 +46,36 @@ kompira ユーザからパスワード接続できるように、pg_hba.conf (RH
 
 以下のコマンドを実行して Kompira Enterprise 開始します。
 
+```
 $ export LOCAL_UID=$UID LOCAL_GID=$(id -g)
-
 $ docker compose pull
 $ docker compose up -d
+```
 
 ### システムの停止
 
 Kompira Enterprise を停止するには以下のコマンドを実行します。
 
+```
 $ docker compose stop
+```
 
 ### システムの再開
 
 停止した Kompira Enterprise を再開するには以下のコマンドを実行します。
 (代わりに docker compose up -d を使うことも可能です)
 
+```
 $ docker compose start
+```
 
 ### システムの削除
 
 以下のコマンドを実行すると、システムが停止し、すべてのコンテナとデータボリュームが削除されます。
 (PostgreSQL データベースのデータは削除されません)
 
-
+```
 $ docker compose down -v
+```
 
 -v オプションを指定しない場合、コンテナのみ削除され、データボリュームは残されます。

--- a/withoutdb/docker-compose.yml
+++ b/withoutdb/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     volumes:
       - ../configs/fluentd.conf:/fluentd/etc/fluent.conf:ro
       - ./log:/var/log/fluentd
+    environment:
+      TZ: ${TZ:-Asia/Tokyo}
+      LOCAL_UID: ${LOCAL_UID:?LOCAL_UID must be set, try "export LOCAL_UID=$$(id -u $${USER})"}
+      LOCAL_GID: ${LOCAL_GID:?LOCAL_GID must be set, try "export LOCAL_GID=$$(id -g $${USER})"}
     user: "${LOCAL_UID}:${LOCAL_GID}"
     ports:
       - "24224:24224"
@@ -14,12 +18,13 @@ services:
     restart: always
   kompira:
     container_name: kompira-app
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
     environment:
       - DATABASE_URL=pgsql://kompira:kompira@host.docker.internal:5432/kompira
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - CACHE_URL=redis://redis:6379
-      - TZ=Asia/Tokyo
+      - LANGUAGE_CODE=${LANGUAGE_CODE:-ja}
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira_audit.yaml:/opt/kompira/kompira_audit.yaml:ro
@@ -38,12 +43,13 @@ services:
     restart: always
   kengine:
     container_name: kompira-engine
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
     environment:
       - DATABASE_URL=pgsql://kompira:kompira@host.docker.internal:5432/kompira
       - AMQP_URL=amqp://guest:guest@rabbitmq:5672
       - CACHE_URL=redis://redis:6379
-      - TZ=Asia/Tokyo
+      - LANGUAGE_CODE=${LANGUAGE_CODE:-ja}
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira_audit.yaml:/opt/kompira/kompira_audit.yaml:ro
@@ -64,7 +70,9 @@ services:
     restart: always
   jobmngrd:
     container_name: kompira-jobmngr
-    image: kompira.azurecr.io/kompira-enterprise:latest
+    image: ${IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${IMAGE_TAG:-latest}
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/kompira.conf:/opt/kompira/kompira.conf:ro
@@ -84,6 +92,8 @@ services:
   redis:
     container_name: kompira-cache
     image: redis:7.2-alpine
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_redis:/data
     logging:
@@ -97,6 +107,8 @@ services:
   nginx:
     container_name: kompira-web
     image: nginx:1.25-alpine
+    environment:
+      - TZ=${TZ:-Asia/Tokyo}
     volumes:
       - kompira_var:/var/opt/kompira
       - ../configs/nginx-default.conf:/etc/nginx/conf.d/default.conf:ro
@@ -119,6 +131,7 @@ services:
       - kompira_mq:/var/lib/rabbitmq     # volume名を明示的に指定 (指定しないとハッシュ化された文字列のボリューム名が使われてゴミが増える)
     environment:
       RABBITMQ_DATA_DIR: /var/lib/rabbitmq    # デフォルト値なので指定不要だが、ボリュームのマウントポイントと一致させるために明示的に指定しておく
+      TZ: ${TZ:-Asia/Tokyo}
     logging:
       driver: fluentd
       options:


### PR DESCRIPTION
kompira-v2 リポジトリでの docker-compose.yml への修正を移植しました。

- docker compose で環境変数 IMAGE_NAME, IMAGE_TAG, TZ, LANGUAGE_CODE を指定できるようにしました。
- docker compose で環境変数 LOCAL_UID, LOCAL_GID が設定されていることをチェックするようにしました。
- 新規サーバにて現在登録されているイメージで allinone デプロイして起動することを確認済みです。