### PR TITLE
issue15: 環境変数でロギング設定を指定できるようにしました

### DIFF
--- a/ke2/services/jobmngrd.yml
+++ b/ke2/services/jobmngrd.yml
@@ -6,11 +6,14 @@ services:
     environment:
       - AMQP_URL=${AMQP_URL:-amqp://guest:guest@rabbitmq:5672}
       - TZ=${TZ:-Asia/Tokyo}
+      - LOGGING_LEVEL=${JOBMNGRD_LOGGING_LEVEL:-${LOGGING_LEVEL:-INFO}}
+      - LOGGING_NAME=jobmngrd
     configs:
       - source: kompira-config
         target: /opt/kompira/kompira.conf
     volumes:
       - ${KOMPIRA_VAR_DIR:-kompira_var}:/var/opt/kompira
+      - ${KOMPIRA_LOG_DIR:-kompira_log}:/var/log/kompira
     extra_hosts:
       - host.docker.internal:host-gateway
     command: ["jobmngrd"]
@@ -22,3 +25,4 @@ configs:
     file: ../../configs/kompira.conf
 volumes:
   kompira_var:
+  kompira_log:

--- a/ke2/services/kompira.yml
+++ b/ke2/services/kompira.yml
@@ -1,12 +1,6 @@
-x-kompira-common:
-  &kompira-common
+x-kompira-common-settings:
+  &kompira-common-settings
   image: ${KOMPIRA_IMAGE_NAME:-kompira.azurecr.io/kompira-enterprise}:${KOMPIRA_IMAGE_TAG:-latest}
-  environment:
-    - DATABASE_URL=${DATABASE_URL:-pgsql://kompira:kompira@${DATABASE_HOST:-postgres}:5432/kompira}
-    - AMQP_URL=${AMQP_URL:-amqp://guest:guest@rabbitmq:5672}
-    - CACHE_URL=${CACHE_URL:-redis://redis:6379}
-    - LANGUAGE_CODE=${LANGUAGE_CODE:-ja}
-    - TZ=${TZ:-Asia/Tokyo}
   configs:
     - source: kompira-audit
       target: /opt/kompira/kompira_audit.yaml
@@ -16,9 +10,21 @@ x-kompira-common:
   extra_hosts:
     - host.docker.internal:host-gateway
 
+x-kompira-common-environ:
+  &kompira-common-environ
+  DATABASE_URL: ${DATABASE_URL:-pgsql://kompira:kompira@${DATABASE_HOST:-postgres}:5432/kompira}
+  AMQP_URL: ${AMQP_URL:-amqp://guest:guest@rabbitmq:5672}
+  CACHE_URL: ${CACHE_URL:-redis://redis:6379}
+  LANGUAGE_CODE: ${LANGUAGE_CODE:-ja}
+  TZ: ${TZ:-Asia/Tokyo}
+
 services:
   kengine:
-    <<: *kompira-common
+    <<: *kompira-common-settings
+    environment:
+      <<: *kompira-common-environ
+      LOGGING_LEVEL: ${KENGINE_LOGGING_LEVEL:-${LOGGING_LEVEL:-INFO}}
+      LOGGING_NAME: kengine
     hostname: ke-${HOSTNAME}
     init: true
     command: ["kompirad"]
@@ -26,7 +32,11 @@ services:
       nproc: 65535
       nofile: 65535
   kompira:
-    <<: *kompira-common
+    <<: *kompira-common-settings
+    environment:
+      <<: *kompira-common-environ
+      LOGGING_LEVEL: ${KOMPIRA_LOGGING_LEVEL:-${LOGGING_LEVEL:-INFO}}
+      LOGGING_NAME: kompira
     hostname: ap-${HOSTNAME}
     init: true
     command: ["uwsgi"]


### PR DESCRIPTION
#15 に対応しました。

- 環境変数 LOGGING_LEVEL で kompira, kengine, jobmngrd のログレベルを指定できます。
- 環境変数 KOMPIRA_LOGGING_LEVEL, KENGINE_LOGGING_LEVEL, JOBMNGRD_LOGGING_LEVEL でサービス個別にログレベルを指定できます（LOGGING_LEVEL より優先します）。